### PR TITLE
Do not use alias for `execute_field_lazy` to call proper `super` method

### DIFF
--- a/lib/graphql/coverage/trace.rb
+++ b/lib/graphql/coverage/trace.rb
@@ -11,7 +11,12 @@ module GraphQL
         result
       end
 
-      alias execute_field_lazy execute_field
+      def execute_field_lazy(field:, query:, ast_node:, arguments:, object:)
+        result = super
+        # TODO: result type
+        Store.current.append(Call.from_graphql_object(field: field, result_type: nil))
+        result
+      end
     end
   end
 end


### PR DESCRIPTION
Previously I used an alias for `execute_field_lazy`. So, it calls `execute_field` as the `super` method unexpectedly.
We need to define individual method to avoid this problem.