### PR TITLE
Insert a new line before displaying the coverage result

### DIFF
--- a/lib/graphql/coverage.rb
+++ b/lib/graphql/coverage.rb
@@ -55,6 +55,7 @@ module GraphQL
         output.puts "#{ignored_size} / #{available_size} fields ignored (#{ignore_rate}%)" if 0 < ignored_size
       end
 
+      puts
       if res.uncovered_fields.empty?
         output.puts "All fields are covered"
         puts_rate.call


### PR DESCRIPTION
Because RSpec progress dot doesn't insert new line before this output