### PR TITLE
Remove unnecessary `gems` entries from rbs_collection.yaml

### DIFF
--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 4b0d2f72e63b6c3e92dc54e19ce23dd24524f9a7
+    revision: be76a75932e8ed6ee91a95ba936cf88b674bf044
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -9,9 +9,6 @@ sources:
 path: .gem_rbs_collection
 
 gems:
-  - name: graphql-coverage
-    ignore: true
-  - name: graphql
   - name: json
   - name: pathname
   - name: optparse


### PR DESCRIPTION
Because the latest RBS avoids duplication gems loaded from gemspec